### PR TITLE
Where assets and libraries were fetched with http, updated to https

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-docs",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appliedblockchain/koa-docs",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "An automatic documentation generator for koa.js APIs ",
   "main": "src/main.js",
   "scripts": {

--- a/src/template.js
+++ b/src/template.js
@@ -4,7 +4,7 @@ const m = require('mithril');
 const path = require('path');
 const fs = require('fs');
 
-const bootstrap = file => `http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/${file}`;
+const bootstrap = file => `https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/${file}`;
 const swatch = file => `https://maxcdn.bootstrapcdn.com/bootswatch/3.3.5/${file}`;
 
 const doctype = '<!DOCTYPE html>';
@@ -60,7 +60,7 @@ module.exports = function renderTemplate (opts) {
             ]),
 
             // Scripts
-            m('script', { src: 'http://code.jquery.com/jquery-2.1.4.min.js' }),
+            m('script', { src: 'https://code.jquery.com/jquery-2.1.4.min.js' }),
             m('script', { src: bootstrap('js/bootstrap.min.js') }),
             m.trust(`<script>${js}</script>`)
          ])


### PR DESCRIPTION
https://zube.io/applied-blockchain/products/c/245

Before:
<img width="1100" alt="screen shot 2019-01-25 at 12 49 17" src="https://user-images.githubusercontent.com/9632022/51746914-b29c7e00-209f-11e9-90bd-c516da7eeef0.png">

After:
<img width="1158" alt="screen shot 2019-01-25 at 12 48 55" src="https://user-images.githubusercontent.com/9632022/51746919-b8925f00-209f-11e9-8f80-5ccd1482af12.png">

